### PR TITLE
Allow Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.2 | ^8.0",
         "payum/core": "^1.6.1",
         "omnipay/common": "^3.0",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "php-http/guzzle6-adapter": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Apparently Guzzle 7 support was accidentally removed by https://github.com/Payum/OmnipayV3Bridge/pull/4.