### PR TITLE
Removes the dependency on Guzzle 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         "php": "^7.2 | ^8.0",
         "payum/core": "^1.6.1",
         "omnipay/common": "^3.0",
-        "guzzlehttp/guzzle": "^6.0",
-        "php-http/guzzle6-adapter": "^2.0"
+        "php-http/client-implementation": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.5",

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
     "require": {
         "php": "^7.2 | ^8.0",
         "payum/core": "^1.6.1",
-        "omnipay/common": "^3.0",
+        "omnipay/common": "^3.1",
         "php-http/client-implementation": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.5",
         "omnipay/dummy": "^3.0",
-        "php-http/guzzle6-adapter": "^2.0"
+        "php-http/guzzle7-adapter": "^1.0"
     },
     "suggest": {
         "php-http/guzzle7-adapter": "Guzzle 7 HTTP Adapter"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.2 | ^8.0",
         "payum/core": "^1.6.1",
-        "omnipay/common": "^3.1",
+        "omnipay/common": "^3.2",
         "php-http/client-implementation": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
         "omnipay/dummy": "^3.0",
         "php-http/guzzle6-adapter": "^2.0"
     },
+    "suggest": {
+        "php-http/guzzle7-adapter": "Guzzle 7 HTTP Adapter"
+    },
     "config": {
         "bin-dir": "bin"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.5",
-        "omnipay/dummy": "^3.0"
+        "omnipay/dummy": "^3.0",
+        "php-http/guzzle6-adapter": "^2.0"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
And allow any other http client implementation to be used.

See #11